### PR TITLE
adding logic to handle windows line endings when content is pasted on…

### DIFF
--- a/component/src/utils/paste/CSV/parseCSVClipboardText.ts
+++ b/component/src/utils/paste/CSV/parseCSVClipboardText.ts
@@ -6,6 +6,8 @@ export class ParseCSVClipboardText {
   public static readonly NEW_LINE_SYMBOL = '\\n';
   private static readonly EXPLICIT_TAB_SYMBOL = '\\\\t';
   private static readonly EXPLICIT_NEW_LINE_SYMBOL = '\\\\n';
+  private static readonly WINDOWS_NEW_LINE_SYMBOL = '\\r\\n';
+  private static readonly EXPLICIT_WINDOWS_NEW_LINE_SYMBOL = '\\\\r\\\\n';
 
   private static preprocessText(multiLineString: string): string {
     let newString = multiLineString;
@@ -20,6 +22,17 @@ export class ParseCSVClipboardText {
 
   private static getSeparatorSymbols(multiLineString: string): {newLine: string; tab: string} {
     // occurs when pasting string that contains actual \n or \t symbols
+
+    // Handle Windows-style line endings (`\r\n`)
+    if (multiLineString.indexOf(ParseCSVClipboardText.EXPLICIT_WINDOWS_NEW_LINE_SYMBOL) > -1) {
+      return {
+        newLine: ParseCSVClipboardText.EXPLICIT_WINDOWS_NEW_LINE_SYMBOL, tab: ParseCSVClipboardText.EXPLICIT_TAB_SYMBOL
+      };
+    }
+    if (multiLineString.indexOf(ParseCSVClipboardText.WINDOWS_NEW_LINE_SYMBOL) > -1) {
+      return { newLine: ParseCSVClipboardText.WINDOWS_NEW_LINE_SYMBOL, tab: ParseCSVClipboardText.TAB_SYMBOL };
+    }
+    // Handle Unix-style line endings (`\n`)
     if (
       multiLineString.indexOf(ParseCSVClipboardText.EXPLICIT_NEW_LINE_SYMBOL) > -1 ||
       multiLineString.indexOf(ParseCSVClipboardText.EXPLICIT_TAB_SYMBOL) > -1


### PR DESCRIPTION
… Windows machines.

This commit closes issue #49. On Windows machines, when data with "\r\n" line endings was pasted, the active table cells would retain "\r" at the last cell in each row as shown below:
![active-table-windows-line-ending-issue-on-paste](https://github.com/user-attachments/assets/aaaf7624-9bfc-49a7-aabb-c837925459f6)

This commit handles Windows style line endings, fixing the issue as shown below:
![fixed-active-table-windows-line-ending-issue](https://github.com/user-attachments/assets/3edd39b6-462b-446d-acd3-05667182fd1b)

